### PR TITLE
Ignore null/falsy children in Masonry

### DIFF
--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -7,6 +7,7 @@ class Masonry extends React.Component {
     const columns = Array.from({length: columnsCount}, () => [])
 
     React.Children.forEach(children, (child, index) => {
+      if(typeof child !== "number" && !child) return null
       columns[index % columnsCount].push(child)
     })
 


### PR DESCRIPTION
This commit is the fix for https://github.com/cedricdelpoux/react-responsive-masonry/issues/42 issue.

In this, we simply ignore `falsy` children to get added in the `columns` array so that this doesn't break the UI.