### PR TITLE
Fix SSR render mismatch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 ## Demo Development Server
 
-* `npm run demo:start` will run a development server with the component's demo app at [http://localhost:1190](http://localhost:1190) with hot module reloading.
+* `npm run start` will run a development server with the component's demo app at [http://localhost:1190](http://localhost:1190) with hot module reloading.
 
 ## Linting
 

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -15,15 +15,6 @@ class Masonry extends React.Component {
     return columns
   }
 
-  renderColumn(column) {
-    const {gutter} = this.props
-    return column.map((item, i) => (
-      <div key={i} style={{marginTop: i > 0 ? gutter : undefined}}>
-        {item}
-      </div>
-    ))
-  }
-
   renderColumns() {
     const {gutter} = this.props
     return this.getColumns().map((column, i) => (
@@ -36,10 +27,10 @@ class Masonry extends React.Component {
           alignContent: "stretch",
           flex: 1,
           width: 0,
-          marginLeft: i > 0 ? gutter : undefined,
+          gap: gutter,
         }}
       >
-        {this.renderColumn(column)}
+        {column.map((item) => item)}
       </div>
     ))
   }
@@ -55,6 +46,7 @@ class Masonry extends React.Component {
           alignContent: "stretch",
           boxSizing: "border-box",
           width: "100%",
+          gap: this.props.gutter,
           ...style,
         }}
         className={className}

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -36,7 +36,7 @@ class Masonry extends React.Component {
   }
 
   render() {
-    const {className, style} = this.props
+    const {gutter, className, style} = this.props
     return (
       <div
         style={{
@@ -46,7 +46,7 @@ class Masonry extends React.Component {
           alignContent: "stretch",
           boxSizing: "border-box",
           width: "100%",
-          gap: this.props.gutter,
+          gap: gutter,
           ...style,
         }}
         className={className}

--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -3,26 +3,30 @@ import React, {useCallback, useEffect, useMemo, useState} from "react"
 
 const DEFAULT_COLUMNS_COUNT = 1
 
-const getWindowWidth = () => {
-  if (typeof window === "undefined") return null
-
-  return window.innerWidth
+const useHasMounted = () => {
+  const [hasMounted, setHasMounted] = useState(false)
+  useEffect(() => {
+    setHasMounted(true)
+  }, [])
+  return hasMounted
 }
 
 const useWindowWidth = () => {
-  const [width, setWidth] = useState(getWindowWidth())
-  const hasWindow = typeof window !== "undefined"
+  const hasMounted = useHasMounted()
+  const [width, setWidth] = useState(0)
 
   const handleResize = useCallback(() => {
-    setWidth(getWindowWidth())
-  }, [])
+    if (!hasMounted) return
+    setWidth(window.innerWidth)
+  }, [hasMounted])
 
   useEffect(() => {
-    if (hasWindow) {
+    if (hasMounted) {
       window.addEventListener("resize", handleResize)
+      handleResize()
       return () => window.removeEventListener("resize", handleResize)
     }
-  }, [hasWindow, handleResize])
+  }, [hasMounted, handleResize])
 
   return width
 }


### PR DESCRIPTION
- Fixes #32

Additional improvements:
- Does not create a new `div` for every element, just the grid and the column. The elements inside the column are exactly the passed children.
- Does not use `margin`s. It uses the [`gap` property](https://caniuse.com/?search=flexbox%20gap) instead.