### PR TITLE
docs: Add examples of using gutter

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ class MyWrapper extends Component {
 
 ### Mansonry component
 
-| Name         | PropType | Description                   | Default |
-| ------------ | -------- | ----------------------------- | ------- |
-| columnsCount | Number   | Injected by ResponsiveMasonry | 3       |
-| gutter       | String   | Margin surrounding each item  | "0"     |
+| Name         | PropType | Description                                           | Default |
+| ------------ | -------- | ----------------------------------------------------- | ------- |
+| columnsCount | Number   | Injected by ResponsiveMasonry                         | 3       |
+| gutter       | String   | Margin surrounding each item e.g. "10px" or "1.5rem"  | "0"     |
 
 ### ResponsiveMasonry component
 


### PR DESCRIPTION
To help people avoid using a number (instead of a string) and getting this error:
`Warning: Failed prop type: Invalid prop `gutter` of type `number` supplied to `Masonry`, expected `string`.`

Also to illustrate how to have responsive gutters because this was not obvious, see:
https://github.com/cedricdelpoux/react-responsive-masonry/issues/6#issuecomment-344510456