### PR TITLE
fix: use useLayoutEffect instead of useEffect for responsive masonry

### DIFF
--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -1,11 +1,20 @@
 import PropTypes from "prop-types"
-import React, {useCallback, useLayoutEffect, useMemo, useState} from "react"
+import React, {
+  useCallback,
+  useLayoutEffect,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 
 const DEFAULT_COLUMNS_COUNT = 1
 
+const useIsomorphicLayoutEffect =
+  typeof window !== "undefined" ? useLayoutEffect : useEffect
+
 const useHasMounted = () => {
   const [hasMounted, setHasMounted] = useState(false)
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     setHasMounted(true)
   }, [])
   return hasMounted
@@ -20,7 +29,7 @@ const useWindowWidth = () => {
     setWidth(window.innerWidth)
   }, [hasMounted])
 
-  useLayoutEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     if (hasMounted) {
       window.addEventListener("resize", handleResize)
       handleResize()

--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -1,11 +1,11 @@
 import PropTypes from "prop-types"
-import React, {useCallback, useEffect, useMemo, useState} from "react"
+import React, {useCallback, useLayoutEffect, useMemo, useState} from "react"
 
 const DEFAULT_COLUMNS_COUNT = 1
 
 const useHasMounted = () => {
   const [hasMounted, setHasMounted] = useState(false)
-  useEffect(() => {
+  useLayoutEffect(() => {
     setHasMounted(true)
   }, [])
   return hasMounted
@@ -20,7 +20,7 @@ const useWindowWidth = () => {
     setWidth(window.innerWidth)
   }, [hasMounted])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (hasMounted) {
       window.addEventListener("resize", handleResize)
       handleResize()


### PR DESCRIPTION
[useLayoutEffect](https://kentcdodds.com/blog/useeffect-vs-uselayouteffect#uselayouteffect)

This runs synchronously immediately after React has performed all DOM mutations. This can be useful if you need to make DOM measurements (like getting the scroll position or other styles for an element)

so i think this should be used for responsiveMasonry instead of normal useEffect,
this should fix [this issue](https://github.com/cedricdelpoux/react-responsive-masonry/issues/86)