### PR TITLE
Fix: Un even column items when Masonry child is invalid

### DIFF
--- a/demo/src/Examples/Masonry/index.js
+++ b/demo/src/Examples/Masonry/index.js
@@ -6,12 +6,19 @@ import Masonry from "../../../../src"
 
 const images = [
   "https://picsum.photos/200/300?image=1050",
+  null,
   "https://picsum.photos/400/400?image=1039",
+  null,
   "https://picsum.photos/400/400?image=1080",
+  null,
   "https://picsum.photos/200/200?image=997",
   "https://picsum.photos/500/400?image=287",
+  "",
   "https://picsum.photos/400/500?image=955",
+  "",
+  "",
   "https://picsum.photos/200/300?image=916",
+  null,
   "https://picsum.photos/300/300?image=110",
   "https://picsum.photos/300/300?image=206",
 ]
@@ -22,13 +29,17 @@ export default class ExampleMasonry extends React.Component {
       <div>
         <Html html={html} color="#44B39D" />
         <Masonry columnsCount={3} gutter="10px">
-          {images.map((image, i) => (
-            <img
-              key={i}
-              src={image}
-              style={{width: "100%", display: "block"}}
-            />
-          ))}
+          {images.map((image, i) =>
+            image ? (
+              <img
+                key={i}
+                src={image}
+                style={{width: "100%", display: "block"}}
+              />
+            ) : (
+              ""
+            )
+          )}
         </Masonry>
       </div>
     )

--- a/demo/src/Examples/Responsive/index.js
+++ b/demo/src/Examples/Responsive/index.js
@@ -6,10 +6,13 @@ import Masonry, {ResponsiveMasonry} from "../../../../src"
 
 const images = [
   "https://picsum.photos/200/300?image=1050",
+  "",
   "https://picsum.photos/400/400?image=1039",
+  null,
   "https://picsum.photos/400/400?image=1080",
   "https://picsum.photos/200/200?image=997",
   "https://picsum.photos/500/400?image=287",
+  null,
   "https://picsum.photos/400/500?image=955",
   "https://picsum.photos/200/300?image=916",
   "https://picsum.photos/300/300?image=110",
@@ -23,13 +26,17 @@ export default class ExampleResponsiveMasonry extends React.Component {
         <Html html={html} color="#44B39D" />
         <ResponsiveMasonry columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}>
           <Masonry columnsCount={3} gutter="10px">
-            {images.map((image, i) => (
-              <img
-                key={i}
-                src={image}
-                style={{width: "100%", display: "block"}}
-              />
-            ))}
+            {images.map((image, i) =>
+              image ? (
+                <img
+                  key={i}
+                  src={image}
+                  style={{width: "100%", display: "block"}}
+                />
+              ) : (
+                ""
+              )
+            )}
           </Masonry>
         </ResponsiveMasonry>
       </div>

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -5,13 +5,13 @@ class Masonry extends React.Component {
   getColumns() {
     const {children, columnsCount} = this.props
     const columns = Array.from({length: columnsCount}, () => [])
-
-    React.Children.forEach(children, (child, index) => {
+    let validIndex = 0
+    React.Children.forEach(children, (child) => {
       if (child && React.isValidElement(child)) {
-        columns[index % columnsCount].push(child)
+        columns[validIndex % columnsCount].push(child)
+        validIndex++
       }
     })
-
     return columns
   }
 


### PR DESCRIPTION
Hi @cedricdelpoux , 

When we render the Masonry child, sometimes we add an if condition to check if the element is valid.

```
const images = [
  "https://picsum.photos/200/300?image=1050",
  null,
  "https://picsum.photos/400/400?image=1039",
  null,
  "https://picsum.photos/400/400?image=1080",
]

<Masonry columnsCount={3} gutter="10px">
    {images.map((image, i) =>
      image ? (
        <img
          key={i}
          src={image}
          style={{width: "100%", display: "block"}}
        />
      ) : (
        ""
      )
    )}
  </Masonry>
```

In those cases, we may return unwanted empty or null children. This is causing uneven children inside the masonry `getColumns`
function.

![image](https://github.com/cedricdelpoux/react-responsive-masonry/assets/13378125/7aa03e11-a068-4e83-8e38-f6e440ce2d9c)
