### PR TITLE
fix: Fix SSR issues by ensuring window object is accessed only on the client side

### DIFF
--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -22,7 +22,9 @@ const useHasMounted = () => {
 
 const useWindowWidth = () => {
   const hasMounted = useHasMounted()
-  const [width, setWidth] = useState(window.innerWidth)
+  const [width, setWidth] = useState(
+    typeof window !== "undefined" ? window.innerWidth : 0
+  )
 
   const handleResize = useCallback(() => {
     if (!hasMounted) return


### PR DESCRIPTION
**Problem**

The MasonryResponsive component accesses the window object during server-side rendering (SSR), causing errors since window is only available on the client side.

**Solution** 

Initial State Setup: Modified useWindowWidth to set the initial state using typeof window !== "undefined" ? window.innerWidth : 0 to prevent SSR errors.