### PR TITLE
feat: distribute children by height

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /node_modules
 /umd
 *.log
+/.yarn

--- a/README.md
+++ b/README.md
@@ -81,13 +81,14 @@ class MyWrapper extends Component {
 
 ### Mansonry component
 
-| Name         | PropType | Description                                           | Default |
-| ------------ | -------- | ----------------------------------------------------- | ------- |
-| columnsCount | Number   | Injected by ResponsiveMasonry                         | 3       |
-| gutter       | String   | Margin surrounding each item e.g. "10px" or "1.5rem"  | "0"     |
-| containerTag | String   | Tag name of the container element                     | "div"   |
-| itemTag      | String   | Tag name of the item element                          | "div"   |
-| itemStyle    | Object   | Style object applied to each item                     | {}      |
+| Name         | PropType | Description                                            | Default |
+| ------------ | -------- | ------------------------------------------------------ | ------- |
+| columnsCount | Number   | Injected by ResponsiveMasonry                          | 3       |
+| gutter       | String   | Margin surrounding each item e.g. "10px" or "1.5rem"   | "0"     |
+| containerTag | String   | Tag name of the container element                      | "div"   |
+| itemTag      | String   | Tag name of the item element                           | "div"   |
+| itemStyle    | Object   | Style object applied to each item                      | {}      |
+| sequential   | Boolean  | If true, items are placed in the order they are passed | false   |
 
 ### ResponsiveMasonry component
 

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -2,22 +2,78 @@ import PropTypes from "prop-types"
 import React from "react"
 
 class Masonry extends React.Component {
-  getColumns() {
+  componentDidUpdate() {
+    if (!this.state.hasDistributed) this.distributeChildren()
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const {children, columnsCount} = props
+    if (state && children === state.children) return null
+    return {
+      ...Masonry.getEqualCountColumns(children, columnsCount),
+      children,
+      hasDistributed: false,
+    }
+  }
+
+  distributeChildren() {
     const {children, columnsCount} = this.props
+    const columnHeights = Array(columnsCount).fill(0)
+
+    const isReady = this.state.childRefs.every(
+      (ref) => ref.current.getBoundingClientRect().height
+    )
+
+    if (!isReady) return
+
     const columns = Array.from({length: columnsCount}, () => [])
     let validIndex = 0
     React.Children.forEach(children, (child) => {
       if (child && React.isValidElement(child)) {
-        columns[validIndex % columnsCount].push(child)
+        // .current is undefined if ref was passed to a functional component without forwardRef
+        // now passing ref into a wrapper div so it should always be defined
+        const childHeight =
+          this.state.childRefs[validIndex].current.getBoundingClientRect()
+            .height
+        const minHeightColumnIndex = columnHeights.indexOf(
+          Math.min(...columnHeights)
+        )
+        columnHeights[minHeightColumnIndex] += childHeight
+        columns[minHeightColumnIndex].push(child)
         validIndex++
       }
     })
-    return columns
+
+    this.setState((p) => ({...p, columns, hasDistributed: true}))
+  }
+
+  static getEqualCountColumns(children, columnsCount) {
+    const columns = Array.from({length: columnsCount}, () => [])
+    let validIndex = 0
+    const childRefs = []
+    React.Children.forEach(children, (child) => {
+      if (child && React.isValidElement(child)) {
+        const ref = React.createRef()
+        childRefs.push(ref)
+        columns[validIndex % columnsCount].push(
+          <div
+            style={{display: "flex", justifyContent: "stretch"}}
+            key={validIndex}
+            ref={ref}
+          >
+            {child}
+          </div>
+          // React.cloneElement(child, {ref}) // cannot attach refs to functional components without forwardRef
+        )
+        validIndex++
+      }
+    })
+    return {columns, childRefs}
   }
 
   renderColumns() {
     const {gutter, itemTag, itemStyle} = this.props
-    return this.getColumns().map((column, i) =>
+    return this.state.columns.map((column, i) =>
       React.createElement(
         itemTag,
         {

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -3,7 +3,7 @@ import React from "react"
 
 class Masonry extends React.Component {
   componentDidUpdate() {
-    if (!this.state.hasDistributed) this.distributeChildren()
+    if (!this.state.hasDistributed && !this.props.sequential) this.distributeChildren()
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -129,6 +129,7 @@ Masonry.propTypes = {
   containerTag: PropTypes.string,
   itemTag: PropTypes.string,
   itemStyle: PropTypes.object,
+  sequential: PropTypes.bool,
 }
 
 Masonry.defaultProps = {
@@ -139,6 +140,7 @@ Masonry.defaultProps = {
   containerTag: "div",
   itemTag: "div",
   itemStyle: {},
+  sequential: false,
 }
 
 export default Masonry


### PR DESCRIPTION
Resolves #117

Before:
<img width="300" alt="Screenshot 2024-07-10 at 3 21 06 PM" src="https://github.com/cedricdelpoux/react-responsive-masonry/assets/69733531/b7866ed2-d2c6-4050-8322-bedf57ac2017">

After:
<img width="300" alt="Screenshot 2024-07-10 at 3 19 02 PM" src="https://github.com/cedricdelpoux/react-responsive-masonry/assets/69733531/9f03db57-fe38-4054-bf08-3c136c209b8b">

Uses a greedy algorithm - this keeps items in a similar order as what was passed in. For the best column distribution you probably need some form of sorting the children like [here](https://stackoverflow.com/a/75493731). You could also use something like MUI's masonry's `sequential` prop to use the old distribution algorithm.

This is my first time really working with react class components, so I'm not sure if this is a good method. 
I couldn't really figure out how to get the demo running (had some errors), so I just tested on my own project instead.

Sorry the commit name is misleading, this is not sequential