### PR TITLE
Add responsive gutters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ class MyWrapper extends Component {
 
 ### ResponsiveMasonry component
 
-| Name                    | PropType | Description                                                                    | Default                  |
-| ----------------------- | -------- | ------------------------------------------------------------------------------ | ------------------------ |
-| columnsCountBreakPoints | Object   | Keys are breakpoints in px, values are the columns number                      | {350: 1, 750: 2, 900: 3} |
-| gutterBreakpoints       | Object   | Keys are breakpoints in px, values are the gutter value in any valid CSS value |                          |
+| Name                    | PropType | Description                                                                              | Default                  |
+| ----------------------- | -------- | ---------------------------------------------------------------------------------------- | ------------------------ |
+| columnsCountBreakPoints | Object   | Keys are breakpoints in px, values are the columns number                                | {350: 1, 750: 2, 900: 3} |
+| gutterBreakpoints       | Object   | Keys are breakpoints in px, values are the gutter value in any valid CSS value for 'gap' |                          |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,13 @@ Otherwise, you only need to use the `Masonry` component.
 import React from "react"
 import Masonry, {ResponsiveMasonry} from "react-responsive-masonry"
 
-// The number of columns change by resizing the window
+// The number of columns and the gutter change by resizing the window
 class MyWrapper extends React.Component {
     render() {
         return (
             <ResponsiveMasonry
                 columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}
+                gutterBreakpoints={{350: "12px", 750: "16px", 900: "24px"}}
             >
                 <Masonry>
                     <ChildA />
@@ -60,7 +61,7 @@ class MyWrapper extends React.Component {
     }
 }
 
-// The number of columns don't change by resizing the window
+// The number of columns and the gutter don't change by resizing the window
 class MyWrapper extends Component {
     render() {
         return (
@@ -91,9 +92,10 @@ class MyWrapper extends Component {
 
 ### ResponsiveMasonry component
 
-| Name                    | PropType | Description                                               | Default                  |
-| ----------------------- | -------- | --------------------------------------------------------- | ------------------------ |
-| columnsCountBreakPoints | Object   | Keys are breakpoints in px, values are the columns number | {350: 1, 750: 2, 900: 3} |
+| Name                    | PropType | Description                                                                    | Default                  |
+| ----------------------- | -------- | ------------------------------------------------------------------------------ | ------------------------ |
+| columnsCountBreakPoints | Object   | Keys are breakpoints in px, values are the columns number                      | {350: 1, 750: 2, 900: 3} |
+| gutterBreakpoints       | Object   | Keys are breakpoints in px, values are the gutter value in any valid CSS value |                          |
 
 ## Contributing
 

--- a/demo/src/Examples/Responsive/index.js
+++ b/demo/src/Examples/Responsive/index.js
@@ -24,7 +24,10 @@ export default class ExampleResponsiveMasonry extends React.Component {
     return (
       <div>
         <Html html={html} color="#44B39D" />
-        <ResponsiveMasonry columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}>
+        <ResponsiveMasonry
+          columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}
+          gutterBreakPoints={{350: "5px", 750: "15px", 900: "25px"}}
+        >
           <Masonry columnsCount={3} gutter="10px">
             {images.map((image, i) =>
               image ? (

--- a/demo/src/Examples/Responsive/index.md
+++ b/demo/src/Examples/Responsive/index.md
@@ -19,6 +19,7 @@ class MyWrapper extends React.Component {
         return (
             <ResponsiveMasonry
                 columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}
+                gutterBreakPoints={{350: "5px", 750: "16px", 900: "2rem"}}
             >
                 <Masonry>
                     {images.map((image, i) => (

--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -50,11 +50,7 @@ const MasonryResponsive = ({
     750: 2,
     900: 3,
   },
-  gutterBreakPoints = {
-    350: DEFAULT_GUTTER,
-    750: DEFAULT_GUTTER,
-    900: DEFAULT_GUTTER,
-  },
+  gutterBreakPoints,
   children,
   className = null,
   style = null,

--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -9,7 +9,7 @@ import React, {
 import PropTypes from "prop-types"
 
 const DEFAULT_COLUMNS_COUNT = 1
-const DEFAULT_GUTTER = '10px'
+const DEFAULT_GUTTER = "10px"
 
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect
@@ -53,46 +53,41 @@ const MasonryResponsive = ({
   gutterBreakPoints = {
     350: DEFAULT_GUTTER,
     750: DEFAULT_GUTTER,
-    900: DEFAULT_GUTTER
+    900: DEFAULT_GUTTER,
   },
   children,
   className = null,
   style = null,
 }) => {
   const windowWidth = useWindowWidth()
-  const columnsCount = useMemo(() => {
-    const breakPoints = Object.keys(columnsCountBreakPoints).sort(
-      (a, b) => a - b
-    )
-    let count =
-      breakPoints.length > 0
-        ? columnsCountBreakPoints[breakPoints[0]]
-        : DEFAULT_COLUMNS_COUNT
 
-    breakPoints.forEach((breakPoint) => {
-      if (breakPoint < windowWidth) {
-        count = columnsCountBreakPoints[breakPoint]
-      }
-    })
+  const getResponsiveValue = useCallback(
+    (breakPoints, defaultValue) => {
+      const sortedBreakPoints = Object.keys(breakPoints).sort((a, b) => a - b)
+      let value =
+        sortedBreakPoints.length > 0
+          ? breakPoints[sortedBreakPoints[0]]
+          : defaultValue
 
-    return count
-  }, [windowWidth, columnsCountBreakPoints])
+      sortedBreakPoints.forEach((breakPoint) => {
+        if (breakPoint < windowWidth) {
+          value = breakPoints[breakPoint]
+        }
+      })
 
-  const gutter = useMemo(() => {
-    const breakpoints = Object.keys(gutterBreakPoints).sort((a, b) => a - b);
+      return value
+    },
+    [windowWidth]
+  )
 
-    let count = breakpoints.length > 0
-      ? gutterBreakPoints[breakpoints[0]]
-      : DEFAULT_GUTTER
-
-    breakpoints.forEach((breakPoint) => {
-      if (breakPoint < windowWidth) {
-        count = gutterBreakPoints[breakPoint]
-      }
-    })
-
-    return count
-  })
+  const columnsCount = useMemo(
+    () => getResponsiveValue(columnsCountBreakPoints, DEFAULT_COLUMNS_COUNT),
+    [getResponsiveValue, columnsCountBreakPoints]
+  )
+  const gutter = useMemo(
+    () => getResponsiveValue(gutterBreakPoints, DEFAULT_GUTTER),
+    [getResponsiveValue, gutterBreakPoints]
+  )
 
   return (
     <div className={className} style={style}>

--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -9,6 +9,7 @@ import React, {
 import PropTypes from "prop-types"
 
 const DEFAULT_COLUMNS_COUNT = 1
+const DEFAULT_GUTTER = '10px'
 
 const useIsomorphicLayoutEffect =
   typeof window !== "undefined" ? useLayoutEffect : useEffect
@@ -49,6 +50,11 @@ const MasonryResponsive = ({
     750: 2,
     900: 3,
   },
+  gutterBreakPoints = {
+    350: DEFAULT_GUTTER,
+    750: DEFAULT_GUTTER,
+    900: DEFAULT_GUTTER
+  },
   children,
   className = null,
   style = null,
@@ -72,12 +78,29 @@ const MasonryResponsive = ({
     return count
   }, [windowWidth, columnsCountBreakPoints])
 
+  const gutter = useMemo(() => {
+    const breakpoints = Object.keys(gutterBreakPoints).sort((a, b) => a - b);
+
+    let count = breakpoints.length > 0
+      ? gutterBreakPoints[breakpoints[0]]
+      : DEFAULT_GUTTER
+
+    breakpoints.forEach((breakPoint) => {
+      if (breakPoint < windowWidth) {
+        count = gutterBreakPoints[breakPoint]
+      }
+    })
+
+    return count
+  })
+
   return (
     <div className={className} style={style}>
       {React.Children.map(children, (child, index) =>
         React.cloneElement(child, {
           key: index,
-          columnsCount: columnsCount,
+          columnsCount,
+          gutter,
         })
       )}
     </div>

--- a/src/ResponsiveMasonry/index.test.js
+++ b/src/ResponsiveMasonry/index.test.js
@@ -10,16 +10,17 @@ import ResponsiveMasonry from "./"
 configure({adapter: new Adapter()})
 
 const columnsCountBreakPoints = {350: 1, 750: 2, 900: 3}
+const gutterBreakPoints = { 350: '10px', 750: '20px', 900: '30px' }
 const content = "Content"
 const ResponsiveFixture = (
-  <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints}>
+  <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints} gutterBreakPoints={gutterBreakPoints}>
     <Masonry>
       <div>{content}</div>
     </Masonry>
   </ResponsiveMasonry>
 )
 const ResponsiveCustomTagsFixture = (
-  <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints}>
+  <ResponsiveMasonry columnsCountBreakPoints={columnsCountBreakPoints} gutterBreakPoints={gutterBreakPoints}>
     <Masonry containerTag="ul" itemTag="li">
       <div>{content}</div>
       <div>{content}</div>


### PR DESCRIPTION
Came across a very old issue where responsive gutters were requested: #6. Thought that shouldn't be that hard to accomplish so here's the PR!

This PR adds a `gutterBreakPoints` prop to the `ResponsiveMasonry` component. You can define the gutter as `px`, `rem`s  `ch` or whatever is a valid `gap` value. I reused the logic for the `responsiveColumnsCount` which existed already. I also updated the examples.

@cedricdelpoux Do you think this is how it should work somewhat? Thanks for creating this awesome library, let me know if I need to add anything else in this PR.

## How to test?
Check the examples!