### PR TITLE
fix(masonry): fix columns not updating when window resized

### DIFF
--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -82,7 +82,6 @@ class Masonry extends React.Component {
         validIndex++
       }
     })
-
     return {columns, childRefs}
   }
 
@@ -112,11 +111,6 @@ class Masonry extends React.Component {
   render() {
     const {gutter, className, style, containerTag} = this.props
 
-    console.log(
-      "getDerivedStateFromProps::render::::::",
-      this.props.columnsCount,
-      this.state.columns.length
-    )
     return React.createElement(
       containerTag,
       {

--- a/src/Masonry/index.js
+++ b/src/Masonry/index.js
@@ -3,22 +3,31 @@ import React from "react"
 
 class Masonry extends React.Component {
   constructor() {
-    super();
-    this.state = { columns: [], childRefs: [], hasDistributed: false };
+    super()
+    this.state = {columns: [], childRefs: [], hasDistributed: false}
   }
 
   componentDidUpdate() {
-    if (!this.state.hasDistributed && !this.props.sequential) this.distributeChildren()
+    if (!this.state.hasDistributed && !this.props.sequential)
+      this.distributeChildren()
   }
 
   static getDerivedStateFromProps(props, state) {
     const {children, columnsCount} = props
-    if (state && children === state.children) return null
+    const hasColumnsChanged = columnsCount !== state.columns.length
+    if (state && children === state.children && !hasColumnsChanged) return null
     return {
       ...Masonry.getEqualCountColumns(children, columnsCount),
       children,
       hasDistributed: false,
     }
+  }
+
+  shouldComponentUpdate(nextProps) {
+    return (
+      nextProps.children !== this.state.children ||
+      nextProps.columnsCount !== this.props.columnsCount
+    )
   }
 
   distributeChildren() {
@@ -73,6 +82,7 @@ class Masonry extends React.Component {
         validIndex++
       }
     })
+
     return {columns, childRefs}
   }
 
@@ -102,6 +112,11 @@ class Masonry extends React.Component {
   render() {
     const {gutter, className, style, containerTag} = this.props
 
+    console.log(
+      "getDerivedStateFromProps::render::::::",
+      this.props.columnsCount,
+      this.state.columns.length
+    )
     return React.createElement(
       containerTag,
       {


### PR DESCRIPTION
### The Issue
columns are not up-to-date when we resizing the window. 
It supposed to be shrink to 2 columns when the window width is bellow the breakpoint.

### The cause
`getDerivedStateFromProps` is only checking children changes,  which caused the `columns` in state is not updated when columnsCount changed.

Other changes: this PR also includes a performance improvement by adding `shouldComponentUpdate` which essentially detects if the columnsCount & children changes.

```jsx
 <ResponsiveMasonry
          columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}
          gutterBreakPoints={{350: "5px", 750: "15px", 900: "25px"}}
        >
          <Masonry columnsCount={3} gutter="10px">
            {images.map((image, i) =>
              image ? (
                <img
                  key={i}
                  src={image}
                  style={{width: "100%", display: "block"}}
                />
              ) : (
                ""
              )
            )}
          </Masonry>
        </ResponsiveMasonry>
```

![masonry-responsive-issue](https://github.com/user-attachments/assets/96ae4fb2-f73b-4b47-a8bc-44ec0363b541)


### Expected result
![masonry-layout-fixed](https://github.com/user-attachments/assets/5a109f24-6f40-459e-a676-db2be18fdc8b)


