### PR TITLE
Set default gutterBreakpoints

### DIFF
--- a/src/ResponsiveMasonry/index.js
+++ b/src/ResponsiveMasonry/index.js
@@ -50,7 +50,7 @@ const MasonryResponsive = ({
     750: 2,
     900: 3,
   },
-  gutterBreakPoints,
+  gutterBreakPoints = {},
   children,
   className = null,
   style = null,


### PR DESCRIPTION
Hotfix to set default breakpoints so things don't break when updating to v2.7.0.