### PR TITLE
Update README: gutterBreakPoints typo, and add class and style props

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class MyWrapper extends React.Component {
         return (
             <ResponsiveMasonry
                 columnsCountBreakPoints={{350: 1, 750: 2, 900: 3}}
-                gutterBreakpoints={{350: "12px", 750: "16px", 900: "24px"}}
+                gutterBreakPoints={{350: "12px", 750: "16px", 900: "24px"}}
             >
                 <Masonry>
                     <ChildA />
@@ -85,6 +85,8 @@ class MyWrapper extends Component {
 | ------------ | -------- | ------------------------------------------------------ | ------- |
 | columnsCount | Number   | Injected by ResponsiveMasonry                          | 3       |
 | gutter       | String   | Margin surrounding each item e.g. "10px" or "1.5rem"   | "0"     |
+| className    | String   | Custom CSS class applied to the container element      | null    |
+| style        | Object   | Style object for customizing the container element     | {}      |
 | containerTag | String   | Tag name of the container element                      | "div"   |
 | itemTag      | String   | Tag name of the item element                           | "div"   |
 | itemStyle    | Object   | Style object applied to each item                      | {}      |
@@ -95,7 +97,7 @@ class MyWrapper extends Component {
 | Name                    | PropType | Description                                                                              | Default                  |
 | ----------------------- | -------- | ---------------------------------------------------------------------------------------- | ------------------------ |
 | columnsCountBreakPoints | Object   | Keys are breakpoints in px, values are the columns number                                | {350: 1, 750: 2, 900: 3} |
-| gutterBreakpoints       | Object   | Keys are breakpoints in px, values are the gutter value in any valid CSS value for 'gap' |                          |
+| gutterBreakPoints       | Object   | Keys are breakpoints in px, values are the gutter value in any valid CSS value for 'gap' |                          |
 
 ## Contributing
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -96,6 +96,12 @@ declare module "react-responsive-masonry" {
      */
     columnsCountBreakPoints?: {[breakpoint: number]: number}
     /**
+     * Breakpoints for the gutter size in the ResponsiveMasonry component.
+     *
+     * @type {{[breakpoint: number]: number}}
+     */
+    gutterBreakPoints?: {[breakpoint: number]: number}
+    /**
      * Class name for the ResponsiveMasonry component container.
      * Default is null.
      *


### PR DESCRIPTION
- Changed `gutterBreakpoints` -> `gutterBreakPoints` in the README
- Added `className` and `style` props in the README
- Added `gutterBreakpoints` to types

`gutterBreakpoints` typo was adding a lot of confusion. Unless the user checked the source code, this prop would be useless.